### PR TITLE
Add turbo support, null checks and prevent duplicate url escaping

### DIFF
--- a/contao/config/config.php
+++ b/contao/config/config.php
@@ -14,7 +14,7 @@ if (System::getContainer()->get('contao.routing.scope_matcher')
 }
 
 $GLOBALS['BE_MOD']['design']['blueprint_article'] = [
-    'tables' => ['tl_blueprint_article_category', 'tl_blueprint_article', 'tl_content'],
+    'tables' => ['tl_blueprint_article_category', 'tl_blueprint_article', 'tl_content', 'tl_article'],
     'blueprint_article_preview' => [Blueprint::class, 'preview'],
     'blueprint_article_insert' => [Blueprint::class, 'insertBlueprint'],
     'article_insert' => [Blueprint::class, 'insertArticles'],

--- a/public/blueprint_insert.js
+++ b/public/blueprint_insert.js
@@ -35,11 +35,24 @@ const toggleBueprint = (previewTrigger, intPage)=>{
     window.dispatchEvent(new CustomEvent("blueprint_preview", {detail: strBlueprint}))
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function initBlueprintPreviews() {
+    // Check if previews already exist (avoid duplicates)
+    if (document.querySelector('[data-previews]')) {
+        return;
+    }
+
+    // Check if we have blueprint elements on the page
+    if (!document.querySelector('[data-blueprint-alias]')) {
+        return;
+    }
+
     //Insert Previews
     const tmp = document.createElement("div")
     tmp.innerHTML = iframes
-    document.querySelector('main').parentNode.append(tmp.firstElementChild)
+    const main = document.querySelector('main')
+    if (main && main.parentNode) {
+        main.parentNode.append(tmp.firstElementChild)
+    }
     let page = 0
 
     document.querySelectorAll('[data-blueprint-alias]').forEach(previewTrigger => {
@@ -56,9 +69,15 @@ window.addEventListener('DOMContentLoaded', () => {
                     const container = iframe.parentNode
                     container.innerHTML = preview
 
-                    container.querySelector('iframe').addEventListener('load', ()=>{
-                        window.dispatchEvent(new Event("blueprint_insert", {detail: intPage}))
-                        toggleBueprint(previewTrigger,intPage)
+                    const iframeElement = container.querySelector('iframe')
+                    iframeElement.addEventListener('load', ()=>{
+                        // Delay to ensure iframe scripts execute before dispatching events
+                        setTimeout(() => {
+                            window.dispatchEvent(new Event("blueprint_insert", {detail: intPage}))
+                            setTimeout(() => {
+                                toggleBueprint(previewTrigger,intPage)
+                            }, 10)
+                        }, 100)
                     }, true)
                 })
             }
@@ -73,7 +92,18 @@ window.addEventListener('DOMContentLoaded', () => {
             toggleBueprint(previewTrigger,intPage)
         })
     })
-});
+}
+
+// Initialize on page load
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initBlueprintPreviews);
+} else {
+    initBlueprintPreviews();
+}
+
+// Reinitialize on Turbo navigation
+document.addEventListener('turbo:load', initBlueprintPreviews);
+document.addEventListener('turbo:render', initBlueprintPreviews);
 
 window.addEventListener("load", () => {
     window.dispatchEvent(new Event("blueprint_insert"))

--- a/public/blueprint_insert.js
+++ b/public/blueprint_insert.js
@@ -36,14 +36,15 @@ const toggleBueprint = (previewTrigger, intPage)=>{
 }
 
 function initBlueprintPreviews() {
-    // Check if previews already exist (avoid duplicates)
-    if (document.querySelector('[data-previews]')) {
-        return;
-    }
-
     // Check if we have blueprint elements on the page
     if (!document.querySelector('[data-blueprint-alias]')) {
         return;
+    }
+
+    // Remove stale preview container (e.g. after Turbo cache restore)
+    const existing = document.querySelector('[data-previews]');
+    if (existing) {
+        existing.remove();
     }
 
     //Insert Previews

--- a/public/blueprint_insert.js
+++ b/public/blueprint_insert.js
@@ -22,6 +22,8 @@ const iframes = `
 
 const iframe = `<iframe class="viewport__content" data-layout="{{ layout }}" data-page="{{ page }}" src="{{ url }}"></iframe>`
 
+let ac = null;
+
 const toggleBueprint = (previewTrigger, intPage)=>{
     const strBlueprint = previewTrigger.dataset.blueprintAlias
 
@@ -36,29 +38,30 @@ const toggleBueprint = (previewTrigger, intPage)=>{
 }
 
 function initBlueprintPreviews() {
-    // Check if we have blueprint elements on the page
+    // Abort any previous listeners (prevents duplicates after Turbo navigation)
+    if (ac) ac.abort();
+    ac = new AbortController();
+    const signal = ac.signal;
+
     if (!document.querySelector('[data-blueprint-alias]')) {
         return;
     }
 
-    // Remove stale preview container (e.g. after Turbo cache restore)
     const existing = document.querySelector('[data-previews]');
     if (existing) {
         existing.remove();
     }
 
-    //Insert Previews
     const tmp = document.createElement("div")
     tmp.innerHTML = iframes
     const main = document.querySelector('main')
     if (main && main.parentNode) {
         main.parentNode.append(tmp.firstElementChild)
     }
-    let page = 0
 
     document.querySelectorAll('[data-blueprint-alias]').forEach(previewTrigger => {
         previewTrigger.addEventListener('mouseenter', () => {
-            intPage = previewTrigger.closest('[data-page]').dataset.page
+            const intPage = previewTrigger.closest('[data-page]').dataset.page
             let preview = document.querySelector(`iframe[data-page='${intPage}']`)
 
             if (!preview) {
@@ -72,7 +75,6 @@ function initBlueprintPreviews() {
 
                     const iframeElement = container.querySelector('iframe')
                     iframeElement.addEventListener('load', ()=>{
-                        // Delay to ensure iframe scripts execute before dispatching events
                         setTimeout(() => {
                             window.dispatchEvent(new Event("blueprint_insert", {detail: intPage}))
                             setTimeout(() => {
@@ -82,16 +84,15 @@ function initBlueprintPreviews() {
                     }, true)
                 })
             }
-        })
+        }, {signal})
     })
 
-    //Set preview visibility
     document.querySelectorAll("[data-blueprint-alias]").forEach(previewTrigger => {
         const intPage = previewTrigger.closest("[data-page]").dataset.page
 
         previewTrigger.addEventListener('mouseenter', () => {
             toggleBueprint(previewTrigger,intPage)
-        })
+        }, {signal})
     })
 }
 

--- a/public/blueprint_preview.js
+++ b/public/blueprint_preview.js
@@ -4,14 +4,15 @@ window.parent.addEventListener("blueprint_insert", (e) => {
     document.querySelectorAll(".mod_article").forEach(article => {
         article.classList.add("--inactive")
     })
+})
 
-    window.parent.addEventListener("blueprint_preview", (e) => {
-        document.querySelector(".mod_article:not(.--inactive)")?.classList.add("--inactive")
+window.parent.addEventListener("blueprint_preview", (e) => {
+    document.querySelector(".mod_article:not(.--inactive)")?.classList.add("--inactive")
 
-        const target = document.querySelector(`#${e.detail}`)
+    const target = document.querySelector(`#${e.detail}`)
+    if (target) {
         target.classList.remove("--inactive")
+    }
 
-        //window.parent.dispatchEvent(new CustomEvent("blueprint_preview_resize", {detail: {'height': target.getBoundingClientRect().height, 'layout':0}}))
-    })
-
+    //window.parent.dispatchEvent(new CustomEvent("blueprint_preview_resize", {detail: {'height': target.getBoundingClientRect().height, 'layout':0}}))
 })

--- a/src/DataContainer/Article.php
+++ b/src/DataContainer/Article.php
@@ -41,11 +41,20 @@ class Article
         $objSession = System::getContainer()->get('request_stack')->getSession();
         $arrClipboard = $objSession->get('CLIPBOARD');
 
-        if (Input::get('key') == 'blueprint_article_insert' || ($arrClipboard['tl_article']['type'] ?? false) == 'blueprint') {
-            // paste button
-            $objSession = System::getContainer()->get('request_stack')->getSession();
-            $arrClipboard = $objSession->get('CLIPBOARD');
+        // Load preview JavaScript (required for Turbo navigation)
+        $objLayoutCollection = LayoutModel::findAll();
+        $arrIFrames = [];
+        foreach ($objLayoutCollection as $objLayout) {
+            $objIFrame = new \stdClass();
+            $objIFrame->url = "/preview.php/kiwi/blueprints/article?do=blueprint_article&key=blueprint_article_preview&layout={$objLayout->id}";
+            $objIFrame->layout = $objLayout->id;
+            $arrIFrames[] = json_encode($objIFrame);
+        }
+        echo "<script>var strBlueprintPreview = '/preview.php/kiwi/blueprints/article?do=blueprint_article&key=blueprint_article_preview';</script>";
+        echo "<script>var arrBlueprintPreviewSrcSet = [" . implode(",", $arrIFrames) . "];</script>";
+        $GLOBALS['TL_JAVASCRIPT'][] = 'bundles/kiwiblueprints/blueprint_insert.js|static';
 
+        if (Input::get('key') == 'blueprint_article_insert' || ($arrClipboard['tl_article']['type'] ?? false) == 'blueprint') {
             $arrClipboard['tl_article'] = [
                 'id' => 0,
                 'type' => 'blueprint',
@@ -54,18 +63,6 @@ class Article
 
             $objSession->set('CLIPBOARD', $arrClipboard);
 
-            // preview
-            $GLOBALS['TL_JAVASCRIPT'][] = 'bundles/kiwiblueprints/blueprint_insert.js';
-            $objLayoutCollection = LayoutModel::findAll();
-            $arrIFrames = [];
-            foreach ($objLayoutCollection as $objLayout) {
-                $objIFrame = new \stdClass();
-                $objIFrame->url = "/preview.php/kiwi/blueprints/article?do=blueprint_article&key=blueprint_article_preview&layout={$objLayout->id}";
-                $objIFrame->layout = $objLayout->id;
-                $arrIFrames[] = json_encode($objIFrame);
-            }
-            echo "<script>var strBlueprintPreview = '/preview.php/kiwi/blueprints/article?do=blueprint_article&key=blueprint_article_preview';</script>";
-            echo "<script>var arrBlueprintPreviewSrcSet = [" . implode(",", $arrIFrames) . "];</script>";
             $GLOBALS['TL_DCA']['tl_article']['list']['sorting']['paste_button_callback'] = [Article::class, 'addBlueprintArticlePasteButton'];
         }
     }

--- a/src/DataContainer/Article.php
+++ b/src/DataContainer/Article.php
@@ -44,11 +44,13 @@ class Article
         // Load preview JavaScript (required for Turbo navigation)
         $objLayoutCollection = LayoutModel::findAll();
         $arrIFrames = [];
-        foreach ($objLayoutCollection as $objLayout) {
-            $objIFrame = new \stdClass();
-            $objIFrame->url = "/preview.php/kiwi/blueprints/article?do=blueprint_article&key=blueprint_article_preview&layout={$objLayout->id}";
-            $objIFrame->layout = $objLayout->id;
-            $arrIFrames[] = json_encode($objIFrame);
+        if ($objLayoutCollection !== null) {
+            foreach ($objLayoutCollection as $objLayout) {
+                $objIFrame = new \stdClass();
+                $objIFrame->url = "/preview.php/kiwi/blueprints/article?do=blueprint_article&key=blueprint_article_preview&layout={$objLayout->id}";
+                $objIFrame->layout = $objLayout->id;
+                $arrIFrames[] = json_encode($objIFrame);
+            }
         }
         echo "<script>var strBlueprintPreview = '/preview.php/kiwi/blueprints/article?do=blueprint_article&key=blueprint_article_preview';</script>";
         echo "<script>var arrBlueprintPreviewSrcSet = [" . implode(",", $arrIFrames) . "];</script>";

--- a/src/DataContainer/Article.php
+++ b/src/DataContainer/Article.php
@@ -81,6 +81,10 @@ class Article
 
         $objBlueprintArticleCategoryCollection = BlueprintArticleCategoryModel::findBy('published', 1, ['order' => 'sorting']);
 
+        if (null === $objBlueprintArticleCategoryCollection) {
+            return '';
+        }
+
         // Add Child entries with Blueprints
         foreach ($objBlueprintArticleCategoryCollection as $objBlueprintArticleCategory) {
             $objBlueprintArticleCollection = BlueprintArticleModel::findPublishedByPidAndTable($objBlueprintArticleCategory->id, ['order' => 'sorting']);
@@ -95,10 +99,13 @@ class Article
 
         $href = Backend::addToUrl('');
 
+        $objPage = PageModel::findById($arrData['pid']);
+        $intLayout = null !== $objPage ? $objPage->loadDetails()->layout : 0;
+
         return System::getContainer()->get('twig')->render('@KiwiBlueprints/backend/blueprint_article_insert.html.twig', [
             'categories' => $objBlueprintArticleCategoryCollection,
             'record' => $arrData,
-            'layout' => PageModel::findById($arrData['pid'])->loadDetails()->layout,
+            'layout' => $intLayout,
             'page' => $strTable == 'tl_article' ? $arrData['pid']:$arrData['id'],
             'href' => $href,
             'icon' => $strTable == 'tl_article' ? "bundles/kiwiblueprints/pasteinto.svg" : "bundles/kiwiblueprints/pastenextto.svg",

--- a/src/Drivers/DC_Table_Blueprint.php
+++ b/src/Drivers/DC_Table_Blueprint.php
@@ -34,13 +34,13 @@ class DC_Table_Blueprint extends DC_Table
             if(($objSession->get('CLIPBOARD')[$this->strTable]['original'] ?? null) == 'tl_blueprint_article') {
                 $intId = Input::get('id') ?? $objSession->get('CLIPBOARD')[$this->strTable]['id'] ?? null;
                 if (!$intId) return null;
-                $objBlueprint = (BlueprintArticleModel::findById($intId))->row();
-                return $objBlueprint;
+                $objBlueprint = BlueprintArticleModel::findById($intId);
+                return $objBlueprint ? $objBlueprint->row() : null;
             }
-        } elseif (Input::get('key') == 'blueprint_article_insert' && Input::get('id') && BlueprintArticleModel::findById(Input::get('id'))) {
-            return (BlueprintArticleModel::findById(Input::get('id')))->row();
-        } elseif (Input::get('key') == 'article_insert') {
-            return (ArticleModel::findById($this->intCurrentRecord))->row();
+        } elseif (Input::get('key') == 'blueprint_article_insert' && Input::get('id') && ($objBlueprint = BlueprintArticleModel::findById(Input::get('id')))) {
+            return $objBlueprint->row();
+        } elseif (Input::get('key') == 'article_insert' && ($objArticle = ArticleModel::findById($this->intCurrentRecord))) {
+            return $objArticle->row();
         }
         return parent::getCurrentRecord($id, $table);
     }

--- a/src/Drivers/DC_Table_Blueprint.php
+++ b/src/Drivers/DC_Table_Blueprint.php
@@ -126,8 +126,8 @@ class DC_Table_Blueprint extends DC_Table
         if ($strRedirectFn) {
             $objSession = System::getContainer()->get('request_stack')->getSession();
             $objSession->set('CLIPBOARD', []);
-            
-            $this->redirect(self::{$strRedirectFn}($intId) . "&do=blueprint_article");
+
+            $this->redirect(Backend::addToUrl('do=blueprint_article&act=edit&id=' . $intId, true, ['key', 'id', 'mode', 'pid']));
         }
         return $this;
     }

--- a/templates/backend/blueprint_article_insert.html.twig
+++ b/templates/backend/blueprint_article_insert.html.twig
@@ -10,7 +10,7 @@
                         <ul class="add_blueprint__item__wrapper blueprint">
                             {% for blueprint in category.blueprints %}
                                 <li class="add_blueprint__wrapper blueprint__wrapper" data-blueprint-alias="{{ blueprint.alias }}">
-                                    <a class="add_blueprint__item blueprint__item item" href="{{ href ~ "&do=blueprint_article&mode=1&mode=" ~ mode ~ "&key=blueprint_article_insert&id=" ~ blueprint.id ~ "&pid=" ~ record.id }}">{{ blueprint.title }}</a>
+                                    <a class="add_blueprint__item blueprint__item item" href="{{ href|raw ~ "&do=blueprint_article&mode=1&mode=" ~ mode ~ "&key=blueprint_article_insert&id=" ~ blueprint.id ~ "&pid=" ~ record.id }}">{{ blueprint.title }}</a>
                                 </li>
                             {% endfor %}
                         </ul>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Turbo navigation support for blueprint previews and insertion, with stronger null checks and safer URL handling. Prevents duplicate preview containers and listeners, avoids errors, and redirects to the new blueprint after copy.

- **New Features**
  - Reinitialize blueprint previews on Turbo (`turbo:load`/`turbo:render`) and on page load; always load preview JS and srcset in the article backend.
  - Add `tl_article` to the `blueprint_article` module tables.

- **Bug Fixes**
  - Add null checks for `BlueprintArticleModel`/`ArticleModel`, guard DOM access in previews, and skip init when no blueprints exist.
  - Prevent duplicates by aborting prior mouseenter listeners with `AbortController`, removing stale preview containers, and avoiding duplicate iframes; delay event dispatch until the iframe loads and ignore hover-triggered inserts.
  - Stop double-escaping insert URLs with `|raw`; after copy, redirect to edit the new blueprint.

<sup>Written for commit 646a7218f2e2d57f7b15f94e243e0bde1f201f93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KIWI-Werbeagentur/contao-blueprint-bundle/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

