### PR TITLE
Build BE url in backend code

### DIFF
--- a/src/DataContainer/Article.php
+++ b/src/DataContainer/Article.php
@@ -87,8 +87,7 @@ class Article
             'mode' => $strTable == 'tl_article' ? 1 : 2,
             'key' => 'blueprint_article_insert',
             'pid' => $arrData['id'],
-        ]));
-
+        ]), true, ['id']);
         // Add Child entries with Blueprints
         foreach ($objBlueprintArticleCategoryCollection as $objBlueprintArticleCategory) {
             $objBlueprintArticleCollection = BlueprintArticleModel::findPublishedByPidAndTable($objBlueprintArticleCategory->id, ['order' => 'sorting']);

--- a/src/DataContainer/Article.php
+++ b/src/DataContainer/Article.php
@@ -82,6 +82,13 @@ class Article
 
         $objBlueprintArticleCategoryCollection = BlueprintArticleCategoryModel::findBy('published', 1, ['order' => 'sorting']);
 
+        $baseHref = Backend::addToUrl(http_build_query([
+            'do' => 'blueprint_article',
+            'mode' => $strTable == 'tl_article' ? 1 : 2,
+            'key' => 'blueprint_article_insert',
+            'pid' => $arrData['id'],
+        ]));
+
         // Add Child entries with Blueprints
         foreach ($objBlueprintArticleCategoryCollection as $objBlueprintArticleCategory) {
             $objBlueprintArticleCollection = BlueprintArticleModel::findPublishedByPidAndTable($objBlueprintArticleCategory->id, ['order' => 'sorting']);
@@ -91,17 +98,18 @@ class Article
                 continue;
             }
 
+            foreach ($objBlueprintArticleCollection as $objBlueprintArticle) {
+                $objBlueprintArticle->href = $baseHref . '&amp;id=' . $objBlueprintArticle->id;
+            }
+
             $objBlueprintArticleCategory->blueprints = $objBlueprintArticleCollection;
         }
-
-        $href = Backend::addToUrl('');
 
         return System::getContainer()->get('twig')->render('@KiwiBlueprints/backend/blueprint_article_insert.html.twig', [
             'categories' => $objBlueprintArticleCategoryCollection,
             'record' => $arrData,
             'layout' => PageModel::findById($arrData['pid'])->loadDetails()->layout,
             'page' => $strTable == 'tl_article' ? $arrData['pid']:$arrData['id'],
-            'href' => $href,
             'icon' => $strTable == 'tl_article' ? "bundles/kiwiblueprints/pasteinto.svg" : "bundles/kiwiblueprints/pastenextto.svg",
             'table' => $strTable,
             'mode' => $strTable == 'tl_article' ? 1 : 2

--- a/templates/backend/blueprint_article_insert.html.twig
+++ b/templates/backend/blueprint_article_insert.html.twig
@@ -10,7 +10,7 @@
                         <ul class="add_blueprint__item__wrapper blueprint">
                             {% for blueprint in category.blueprints %}
                                 <li class="add_blueprint__wrapper blueprint__wrapper" data-blueprint-alias="{{ blueprint.alias }}">
-                                    <a class="add_blueprint__item blueprint__item item" href="{{ href ~ "&do=blueprint_article&mode=1&mode=" ~ mode ~ "&key=blueprint_article_insert&id=" ~ blueprint.id ~ "&pid=" ~ record.id }}">{{ blueprint.title }}</a>
+                                    <a class="add_blueprint__item blueprint__item item" href="{{ blueprint.href|raw }}">{{ blueprint.title }}</a>
                                 </li>
                             {% endfor %}
                         </ul>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Builds the full backend URL for blueprint article insertion in PHP, assigns it to each blueprint, and unsets any existing `id` to prevent duplicate params and fix routing.

- **Bug Fixes**
  - Create base href with `Backend::addToUrl` + `http_build_query` (`do`, `mode` from table, `key`, `pid`), excluding `id`, then append each blueprint `id`.
  - Update `@KiwiBlueprints` Twig to use `blueprint.href` and remove the `href` context variable.

<sup>Written for commit 4a1544e6dc5232f7f48fd70f98c7ab1078faf898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KIWI-Werbeagentur/contao-blueprint-bundle/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

